### PR TITLE
Fix write file header

### DIFF
--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -323,7 +323,7 @@ func (bd *bufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 		Length:    4,
 		VR:        "UL",
 		Data:      []byte{0, 0, 0, 0},
-		BigEndian: false}
+		BigEndian: bd.IsBigEndian()}
 	bd.WriteTag(tag, explicitVR)
 	tag = &DcmTag{
 		Group:     0x02,
@@ -331,7 +331,7 @@ func (bd *bufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 		Length:    2,
 		VR:        "OB",
 		Data:      []byte{0x00, 0x01},
-		BigEndian: false,
+		BigEndian: bd.IsBigEndian(),
 	}
 	bd.WriteTag(tag, explicitVR)
 
@@ -347,9 +347,8 @@ func (bd *bufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 	// calculate group length and go Back to group size tag
 	ptr := bd.GetPosition()
 	largo = uint32(bd.GetSize() - 12 - 128 - 4)
-	binary.BigEndian.PutUint32(buffer, largo)
 	bd.SetPosition(128 + 4 + 8)
-	bd.MS.Write(buffer, 4)
+	bd.WriteUint32(largo)
 	bd.SetPosition(ptr)
 }
 

--- a/openjpeg/j2kcodec_linux_amd64.go
+++ b/openjpeg/j2kcodec_linux_amd64.go
@@ -1,7 +1,7 @@
 package openjpeg
 
 // #cgo CFLAGS: -I j2klib/include -I j2klib/linux_amd64
-// #cgo LDFLAGS: -L j2klib/linux_amd64 -lopenjpeg
+// #cgo LDFLAGS: -L j2klib/linux_amd64 -lopenjpeg -lm
 // #include "j2klib/decomj2k.c"
 // #include "j2klib/comj2k.c"
 import "C"


### PR DESCRIPTION
- Fix write file header 

Error dumping with dcmdump (DCMTK)

> W: DcmMetaInfo: Invalid Element (0008,0005) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0008) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0012) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0013) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0016) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0018) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0020) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0022) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0023) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0030) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0032) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0033) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0050) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0060) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0070) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0080) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0081) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,0090) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1030) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1032) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,103e) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1040) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1090) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0008,1111) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0010,0010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0010,0020) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0010,0030) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0010,0040) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0010,1010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0022) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0050) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0060) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0088) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,0090) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1020) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1030) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1100) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1120) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1130) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1140) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1151) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1152) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1160) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,1210) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0018,5100) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,000d) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,000e) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0011) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0013) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0032) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0037) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,0052) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0020,1041) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0002) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0004) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0010) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0011) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0030) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0100) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0101) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0102) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,0103) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,1050) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,1051) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,1052) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0028,1053) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0032,1032) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0032,1060) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0007) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0008) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0009) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0253) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0254) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0260) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,0275) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (0040,1001) found in Meta Information Header
> W: DcmMetaInfo: Invalid Element (7fe0,0010) found in Meta Information Header
> W: DcmMetaInfo: Group Length of Meta Information Header has incorrect value

- Fix compile error 

> undefined reference to `exp2'