### PR TITLE
Fix dicom writing by selecting the first TS proposed by user

### DIFF
--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -385,6 +385,7 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 		TS := ""
 		for _, TrnSyntax := range PresContext.GetTransferSyntaxes() {
 			TS = TrnSyntax.GetUID()
+			break
 		}
 		if TS == "" {
 			TS = transfersyntax.ImplicitVRLittleEndian.UID


### PR DESCRIPTION
Duplicate https://github.com/t2care/obd-dicom/pull/7
### Error with dcmdump

> W: DcmItem: Non-standard VR ' ' (04\00) encountered while parsing element (0008,0000), assuming 2 byte length field
> W: DcmItem: Non-standard VR ' ' (08\00) encountered while parsing element (0058,0000), assuming 2 byte length field
> W: DcmItem: Element GenericGroupLength (0058,0000) larger (4432) than remaining bytes (84) of surrounding item
> E: dcmdump: Length of element larger than explicit length of surrounding item: reading file: 1-afterLL.dcm

### Before
User proposes `JPEG Lossless` for lossless images, but StoreSCP will only accept `Implicit VR Little Endian`

```
024/08/16 15:58:20 INFO ASSOC-RQ: 	AbstractContext UID=1.2.840.10008.5.1.4.1.1.2 Description="CT Image Storage"
2024/08/16 15:58:20 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.4.70 Description="JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1])"
2024/08/16 15:58:20 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.1 Description="Explicit VR Little Endian"
2024/08/16 15:58:20 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.2 Description="Explicit VR Big Endian"
2024/08/16 15:58:20 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2 Description="Implicit VR Little Endian"
2024/08/16 15:58:20 INFO ASSOC-AC: CallingAE=DCMSEND CalledAE=ANY-SCP
2024/08/16 15:58:20 INFO ASSOC-AC: ImpClass=1.2.826.0.1.3680043.10.90.999
2024/08/16 15:58:20 INFO ASSOC-AC: ImpVersion=OBD-Dicom
2024/08/16 15:58:20 INFO ASSOC-AC: MaxPDULength=16384
2024/08/16 15:58:20 INFO ASSOC-AC: MaxOpsInvoked=0 MaxOpsPerformed=0
2024/08/16 15:58:20 INFO ASSOC-AC: 	Accepted AbstractContext: UID=1.2.840.10008.5.1.4.1.1.2 Description="CT Image Storage"
2024/08/16 15:58:20 INFO ASSOC-AC: 	Accepted TransferSynxtax: UID=1.2.840.10008.1.2 Description="Implicit VR Little Endian"
```
### After
No transcode needed from users
```
2024/08/16 15:53:08 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.4.70 Description="JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1])"
2024/08/16 15:53:08 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.1 Description="Explicit VR Little Endian"
2024/08/16 15:53:08 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2.2 Description="Explicit VR Big Endian"
2024/08/16 15:53:08 INFO ASSOC-RQ: 	TransferSynxtax: UID=1.2.840.10008.1.2 Description="Implicit VR Little Endian"
2024/08/16 15:53:08 INFO ASSOC-AC: CallingAE=DCMSEND CalledAE=ANY-SCP
2024/08/16 15:53:08 INFO ASSOC-AC: ImpClass=1.2.826.0.1.3680043.10.90.999
2024/08/16 15:53:08 INFO ASSOC-AC: ImpVersion=OBD-Dicom
2024/08/16 15:53:08 INFO ASSOC-AC: MaxPDULength=16384
2024/08/16 15:53:08 INFO ASSOC-AC: MaxOpsInvoked=0 MaxOpsPerformed=0
2024/08/16 15:53:08 INFO ASSOC-AC: 	Accepted AbstractContext: UID=1.2.840.10008.5.1.4.1.1.2 Description="CT Image Storage"
2024/08/16 15:53:08 INFO ASSOC-AC: 	Accepted TransferSynxtax: UID=1.2.840.10008.1.2.4.70 Description="JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1])"
```