### PR TITLE
Perf: Optimize loading tags (~ 4x perf)

### DIFF
--- a/dictionary/tags/uids.go
+++ b/dictionary/tags/uids.go
@@ -33,12 +33,3 @@ func getTag(group uint16, element uint16) *Tag {
 func GetTags() []*Tag {
 	return tags
 }
-
-func getGroupElement(Name string) (group uint16, element uint16) {
-	for _, tag := range tags {
-		if tag.Name == Name {
-			return tag.Group, tag.Element
-		}
-	}
-	return 0, 0
-}

--- a/dictionary/tags/uids.go
+++ b/dictionary/tags/uids.go
@@ -10,7 +10,7 @@ type Tag struct {
 	Description string
 }
 
-func GetTagFromName(name string) *Tag {
+func getTagFromName(name string) *Tag {
 	for _, tag := range tags {
 		if tag.Name == name {
 			return tag
@@ -19,8 +19,8 @@ func GetTagFromName(name string) *Tag {
 	return &Tag{}
 }
 
-// GetTag - Get tag from group and element
-func GetTag(group uint16, element uint16) *Tag {
+// getTag - Get tag from group and element
+func getTag(group uint16, element uint16) *Tag {
 	for _, tag := range tags {
 		if tag.Group == group && tag.Element == element {
 			return tag
@@ -34,11 +34,11 @@ func GetTags() []*Tag {
 	return tags
 }
 
-func GetGroupElement(Name string) (group uint16, element uint16) {
+func getGroupElement(Name string) (group uint16, element uint16) {
 	for _, tag := range tags {
 		if tag.Name == Name {
 			return tag.Group, tag.Element
 		}
 	}
-  return 0, 0
+	return 0, 0
 }

--- a/dictionary/tags/uids_test.go
+++ b/dictionary/tags/uids_test.go
@@ -34,7 +34,7 @@ func TestGetTagFromName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTagFromName(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+			if got := getTagFromName(tt.args.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetTagFromName() = %v, want %v", got, tt.want)
 			}
 		})
@@ -71,7 +71,7 @@ func TestGetTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTag(tt.args.group, tt.args.element); !reflect.DeepEqual(got, tt.want) {
+			if got := getTag(tt.args.group, tt.args.element); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetTagFromUID() = %v, want %v", got, tt.want)
 			}
 		})

--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -189,7 +189,7 @@ func (bd *BufData) ReadTag(explicitVR bool) (*DcmTag, error) {
 		}
 	} else {
 		if !internalVR {
-			tag.VR = GetDictionaryVR(tag.Group, tag.Element)
+			tag.VR = getDictionaryVR(tag.Group, tag.Element)
 		}
 		length, err := bd.ReadUint32()
 		if err != nil {
@@ -222,7 +222,7 @@ func (bd *BufData) WriteTag(tag *DcmTag, explicitVR bool) {
 	}
 	if (tag.Group != 0x0000) && (tag.Group != 0xfffe) && (explicitVR) {
 		if tag.VR == "" { // In case converting from illicit
-			tag.VR = GetDictionaryVR(tag.Group, tag.Element)
+			tag.VR = getDictionaryVR(tag.Group, tag.Element)
 		}
 		bd.MS.Write([]byte(tag.VR), 2)
 		if (tag.VR == "OB") || (tag.VR == "OW") || (tag.VR == "SQ") || (tag.VR == "UN") || (tag.VR == "UT") {
@@ -347,7 +347,7 @@ func (bd *BufData) ReadObj(obj *DcmObj) error {
 			return err
 		}
 		if !isExplicitVR {
-			tag.VR = GetDictionaryVR(tag.Group, tag.Element)
+			tag.VR = getDictionaryVR(tag.Group, tag.Element)
 		}
 		if tag.Length%2 != 0 && tag.VR != "SQ" && tag.Length != 0xffffffff {
 			return fmt.Errorf("%s is odd", tag.Name)

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -140,3 +140,8 @@ func changeSyntax(filename string, ts *transfersyntax.TransferSyntax) (err error
 	_, err = NewDCMObjFromBytes(dcmObj.WriteToBytes())
 	return
 }
+func BenchmarkOBD(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewDCMObjFromFile("../samples/test.dcm")
+	}
+}

--- a/media/dcm_tag.go
+++ b/media/dcm_tag.go
@@ -106,7 +106,7 @@ func (tag *DcmTag) ReadSeq(ExplicitVR bool) (*DcmObj, error) {
 		}
 
 		if !ExplicitVR {
-			temptag.VR = GetDictionaryVR(tag.Group, tag.Element)
+			temptag.VR = getDictionaryVR(tag.Group, tag.Element)
 		}
 		switch temptag.Element {
 		case 0xE000:


### PR DESCRIPTION
- Before: `BenchmarkOBD-16    	    5179	    202671 ns/op	  288689 B/op	     778 allocs/op`
- After: `BenchmarkOBD-16    	   18717	     63001 ns/op	  288025 B/op	     769 allocs/op`

