### PR TITLE
Add options for Dicom parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go build -tags jpeg2000 ...
 ### Load DICOM File
 
 ```golang
-obj, err := media.NewDCMObjFromFile(fileName)
+obj, err := media.NewDCMObjFromFile(fileName, &ParseOptions{SkipPixelData: true})
 if err != nil {
   log.Panicln(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/one-byte-data/obd-dicom
 
 go 1.21
-
-require github.com/mattn/go-sqlite3 v1.14.17

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
-github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
-github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
-github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=

--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -146,7 +146,7 @@ func (bd *BufData) WriteString(value string) {
 }
 
 // ReadTag - read a single tag from the Stream
-func (bd *BufData) ReadTag(explicitVR bool, opt ...ParseOptions) (*DcmTag, error) {
+func (bd *BufData) ReadTag(explicitVR bool, opt ...*ParseOptions) (*DcmTag, error) {
 	group, err := bd.ReadUint16()
 	if err != nil {
 		return nil, err
@@ -357,7 +357,7 @@ func (bd *BufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 }
 
 // ReadObj - Read a DICOM Object from a BufData
-func (bd *BufData) ReadObj(obj *DcmObj, opt ...ParseOptions) error {
+func (bd *BufData) ReadObj(obj *DcmObj, opt ...*ParseOptions) error {
 	isExplicitVR := obj.IsExplicitVR()
 	for bd.GetPosition() < bd.GetSize() {
 		tag, err := bd.ReadTag(isExplicitVR, opt...)

--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -221,7 +221,9 @@ func (bd *BufData) ReadTag(explicitVR bool, opt ...ParseOptions) (*DcmTag, error
 			return nil, err
 		}
 	}
-	FillTag(tag)
+	if len(opt) > 1 && opt[0].SkipFillTag {
+		FillTag(tag)
+	}
 	return tag, nil
 }
 

--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -146,10 +146,26 @@ func (bd *BufData) WriteString(value string) {
 }
 
 // ReadTag - read a single tag from the Stream
-func (bd *BufData) ReadTag(explicitVR bool) (*DcmTag, error) {
+func (bd *BufData) ReadTag(explicitVR bool, opt ...ParseOption) (*DcmTag, error) {
 	group, err := bd.ReadUint16()
 	if err != nil {
 		return nil, err
+	}
+	if len(opt) > 0 {
+		stop := false
+		switch group {
+		case 0x0002:
+		case 0x0008:
+			stop = opt[0].OnlyMetaHeader
+		case 0x0010:
+		case 0x7FE0:
+			stop = opt[0].SkipPixelData
+		default:
+			stop = opt[0].UntilPatientTag
+		}
+		if stop {
+			return nil, nil
+		}
 	}
 	element, err := bd.ReadUint16()
 	if err != nil {
@@ -339,12 +355,15 @@ func (bd *BufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 }
 
 // ReadObj - Read a DICOM Object from a BufData
-func (bd *BufData) ReadObj(obj *DcmObj) error {
+func (bd *BufData) ReadObj(obj *DcmObj, opt ...ParseOption) error {
 	isExplicitVR := obj.IsExplicitVR()
 	for bd.GetPosition() < bd.GetSize() {
-		tag, err := bd.ReadTag(isExplicitVR)
+		tag, err := bd.ReadTag(isExplicitVR, opt...)
 		if err != nil {
 			return err
+		}
+		if tag == nil {
+			return nil
 		}
 		if !isExplicitVR {
 			tag.VR = getDictionaryVR(tag.Group, tag.Element)

--- a/media/buf_data.go
+++ b/media/buf_data.go
@@ -146,7 +146,7 @@ func (bd *BufData) WriteString(value string) {
 }
 
 // ReadTag - read a single tag from the Stream
-func (bd *BufData) ReadTag(explicitVR bool, opt ...ParseOption) (*DcmTag, error) {
+func (bd *BufData) ReadTag(explicitVR bool, opt ...ParseOptions) (*DcmTag, error) {
 	group, err := bd.ReadUint16()
 	if err != nil {
 		return nil, err
@@ -355,7 +355,7 @@ func (bd *BufData) WriteMeta(SOPClassUID string, SOPInstanceUID string, Transfer
 }
 
 // ReadObj - Read a DICOM Object from a BufData
-func (bd *BufData) ReadObj(obj *DcmObj, opt ...ParseOption) error {
+func (bd *BufData) ReadObj(obj *DcmObj, opt ...ParseOptions) error {
 	isExplicitVR := obj.IsExplicitVR()
 	for bd.GetPosition() < bd.GetSize() {
 		tag, err := bd.ReadTag(isExplicitVR, opt...)

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -24,7 +24,7 @@ type DcmObj struct {
 	SQtag          *DcmTag
 }
 
-type ParseOption struct {
+type ParseOptions struct {
 	OnlyMetaHeader  bool // Group 0x0002
 	UntilPatientTag bool // Until group 0x0010
 	SkipPixelData   bool
@@ -42,7 +42,7 @@ func NewEmptyDCMObj() *DcmObj {
 }
 
 // NewDCMObjFromFile - Read from a DICOM file into a DICOM Object
-func NewDCMObjFromFile(fileName string, opt ...ParseOption) (*DcmObj, error) {
+func NewDCMObjFromFile(fileName string, opt ...ParseOptions) (*DcmObj, error) {
 	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
 			return nil, errors.New("DcmObj::Read, file does not exist")
@@ -63,7 +63,7 @@ func NewDCMObjFromBytes(data []byte) (*DcmObj, error) {
 	return parseBufData(NewBufDataFromBytes(data))
 }
 
-func parseBufData(bufdata *BufData, opt ...ParseOption) (*DcmObj, error) {
+func parseBufData(bufdata *BufData, opt ...ParseOptions) (*DcmObj, error) {
 	BigEndian := false
 
 	transferSyntax, err := bufdata.ReadMeta()

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -25,9 +25,10 @@ type DcmObj struct {
 }
 
 type ParseOptions struct {
-	OnlyMetaHeader  bool // Group 0x0002
+	OnlyMetaHeader  bool // Group 0x0002. Useful for storeSCU for exemple
 	UntilPatientTag bool // Until group 0x0010
 	SkipPixelData   bool
+	SkipFillTag     bool // Increase perf by skipping FillTag. Filltag is only useful for dumpTags
 }
 
 // NewEmptyDCMObj - Create as an interface to a new empty dcmObj

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -43,7 +43,7 @@ func NewEmptyDCMObj() *DcmObj {
 }
 
 // NewDCMObjFromFile - Read from a DICOM file into a DICOM Object
-func NewDCMObjFromFile(fileName string, opt ...ParseOptions) (*DcmObj, error) {
+func NewDCMObjFromFile(fileName string, opt ...*ParseOptions) (*DcmObj, error) {
 	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
 			return nil, errors.New("DcmObj::Read, file does not exist")
@@ -64,7 +64,7 @@ func NewDCMObjFromBytes(data []byte) (*DcmObj, error) {
 	return parseBufData(NewBufDataFromBytes(data))
 }
 
-func parseBufData(bufdata *BufData, opt ...ParseOptions) (*DcmObj, error) {
+func parseBufData(bufdata *BufData, opt ...*ParseOptions) (*DcmObj, error) {
 	BigEndian := false
 
 	transferSyntax, err := bufdata.ReadMeta()

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -24,6 +24,12 @@ type DcmObj struct {
 	SQtag          *DcmTag
 }
 
+type ParseOption struct {
+	OnlyMetaHeader  bool // Group 0x0002
+	UntilPatientTag bool // Until group 0x0010
+	SkipPixelData   bool
+}
+
 // NewEmptyDCMObj - Create as an interface to a new empty dcmObj
 func NewEmptyDCMObj() *DcmObj {
 	return &DcmObj{
@@ -36,7 +42,7 @@ func NewEmptyDCMObj() *DcmObj {
 }
 
 // NewDCMObjFromFile - Read from a DICOM file into a DICOM Object
-func NewDCMObjFromFile(fileName string) (*DcmObj, error) {
+func NewDCMObjFromFile(fileName string, opt ...ParseOption) (*DcmObj, error) {
 	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
 			return nil, errors.New("DcmObj::Read, file does not exist")
@@ -49,7 +55,7 @@ func NewDCMObjFromFile(fileName string) (*DcmObj, error) {
 		return nil, err
 	}
 
-	return parseBufData(bufdata)
+	return parseBufData(bufdata, opt...)
 }
 
 // NewDCMObjFromBytes - Read from a DICOM bytes into a DICOM Object
@@ -57,7 +63,7 @@ func NewDCMObjFromBytes(data []byte) (*DcmObj, error) {
 	return parseBufData(NewBufDataFromBytes(data))
 }
 
-func parseBufData(bufdata *BufData) (*DcmObj, error) {
+func parseBufData(bufdata *BufData, opt ...ParseOption) (*DcmObj, error) {
 	BigEndian := false
 
 	transferSyntax, err := bufdata.ReadMeta()
@@ -87,7 +93,7 @@ func parseBufData(bufdata *BufData) (*DcmObj, error) {
 	}
 	bufdata.SetBigEndian(BigEndian)
 
-	if err := bufdata.ReadObj(obj); err != nil {
+	if err := bufdata.ReadObj(obj, opt...); err != nil {
 		return nil, err
 	}
 

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -143,44 +143,44 @@ func changeSyntax(filename string, ts *transfersyntax.TransferSyntax) (err error
 }
 func BenchmarkOBD(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		NewDCMObjFromFile("../samples/test.dcm", ParseOptions{UntilPatientTag: true, SkipFillTag: true})
+		NewDCMObjFromFile("../samples/test.dcm")
 	}
 }
 
 func TestParseOptions(t *testing.T) {
 	tests := []struct {
 		name         string
-		opt          ParseOptions
+		opt          *ParseOptions
 		tagCount     int
 		protocolName string
 	}{
 		{
 			name:         "No options",
-			opt:          ParseOptions{},
+			opt:          &ParseOptions{},
 			tagCount:     99,
 			protocolName: "SAG T1 ACR",
 		},
 		{
 			name:         "Skip pixel",
-			opt:          ParseOptions{SkipPixelData: true},
+			opt:          &ParseOptions{SkipPixelData: true},
 			tagCount:     98,
 			protocolName: "SAG T1 ACR",
 		},
 		{
 			name:         "Only meta header",
-			opt:          ParseOptions{OnlyMetaHeader: true},
+			opt:          &ParseOptions{OnlyMetaHeader: true},
 			tagCount:     0,
 			protocolName: "",
 		},
 		{
 			name:         "Until patient tags",
-			opt:          ParseOptions{UntilPatientTag: true},
+			opt:          &ParseOptions{UntilPatientTag: true},
 			tagCount:     30,
 			protocolName: "",
 		},
 		{
 			name:         "Skip FillTag",
-			opt:          ParseOptions{SkipPixelData: true, SkipFillTag: true},
+			opt:          &ParseOptions{SkipPixelData: true, SkipFillTag: true},
 			tagCount:     98,
 			protocolName: "SAG T1 ACR",
 		},

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -145,3 +145,40 @@ func BenchmarkOBD(b *testing.B) {
 		NewDCMObjFromFile("../samples/test.dcm")
 	}
 }
+
+func TestParseOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		opt      ParseOption
+		tagCount int
+	}{
+		{
+			name:     "No options",
+			opt:      ParseOption{},
+			tagCount: 99,
+		},
+		{
+			name:     "Skip pixel",
+			opt:      ParseOption{SkipPixelData: true},
+			tagCount: 98,
+		},
+		{
+			name:     "Only meta header",
+			opt:      ParseOption{OnlyMetaHeader: true},
+			tagCount: 0,
+		},
+		{
+			name:     "Until patient tags",
+			opt:      ParseOption{UntilPatientTag: true},
+			tagCount: 30,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, _ := NewDCMObjFromFile("../samples/test.dcm", tt.opt)
+			if len(o.GetTags()) != tt.tagCount {
+				t.Errorf("TestParseOptions() count = %v, want %v", len(o.GetTags()), tt.tagCount)
+			}
+		})
+	}
+}

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -149,27 +149,27 @@ func BenchmarkOBD(b *testing.B) {
 func TestParseOptions(t *testing.T) {
 	tests := []struct {
 		name     string
-		opt      ParseOption
+		opt      ParseOptions
 		tagCount int
 	}{
 		{
 			name:     "No options",
-			opt:      ParseOption{},
+			opt:      ParseOptions{},
 			tagCount: 99,
 		},
 		{
 			name:     "Skip pixel",
-			opt:      ParseOption{SkipPixelData: true},
+			opt:      ParseOptions{SkipPixelData: true},
 			tagCount: 98,
 		},
 		{
 			name:     "Only meta header",
-			opt:      ParseOption{OnlyMetaHeader: true},
+			opt:      ParseOptions{OnlyMetaHeader: true},
 			tagCount: 0,
 		},
 		{
 			name:     "Until patient tags",
-			opt:      ParseOption{UntilPatientTag: true},
+			opt:      ParseOptions{UntilPatientTag: true},
 			tagCount: 30,
 		},
 	}


### PR DESCRIPTION
# Options:
```
type ParseOptions struct {
	OnlyMetaHeader  bool // Group 0x0002. Useful for storeSCU for exemple
	UntilPatientTag bool // Until group 0x0010
	SkipPixelData   bool
	SkipFillTag     bool // Increase perf by skipping FillTag. Filltag is only useful for dumpTags
}
```
# Benchmark
```
func BenchmarkOBD(b *testing.B) {
	for i := 0; i < b.N; i++ {
		NewDCMObjFromFile("../samples/test.dcm", ParseOptions{UntilPatientTag: true, SkipFillTag: true})
	}
}
```
`BenchmarkOBD-16    	   34143	     35656 ns/op	  146264 B/op	     286 allocs/op`

---> x2 times vs https://github.com/t2care/obd-dicom/pull/18
