### PR TITLE
Fix bug for querySCP

### DIFF
--- a/dimsec/c_find.go
+++ b/dimsec/c_find.go
@@ -71,9 +71,9 @@ func CFindWriteRSP(pdu *network.PDUService, DCO *media.DcmObj, DDO *media.DcmObj
 
 	DCOR.SetTransferSyntax(DCO.GetTransferSyntax())
 
-	leDSType := uint16(0x0101)
+	leDSType := dicomstatus.CommandDataSetTypeNull
 	if DDO.TagCount() > 0 {
-		leDSType = 0x0102
+		leDSType = dicomstatus.CommandDataSetTypeNonNull
 	}
 
 	SOPClassUID := DCO.GetString(tags.AffectedSOPClassUID)
@@ -96,10 +96,7 @@ func CFindWriteRSP(pdu *network.PDUService, DCO *media.DcmObj, DDO *media.DcmObj
 		if err := pdu.Write(DCOR, 0x01); err != nil {
 			return err
 		}
-
-		if DDO.TagCount() > 0 {
-			return pdu.Write(DDO, 0x00)
-		}
+		return pdu.Write(DDO, 0x00)
 	}
 	return errors.New("CFindReadRSP, unknown error")
 }

--- a/network/dicomstatus/statuses.go
+++ b/network/dicomstatus/statuses.go
@@ -26,3 +26,12 @@ const FailureSOPClassNotSupported uint16 = 0x0122
 
 // Failure - 0xc000
 const FailureUnableToProcess uint16 = 0xc000
+
+// CommandDataSetTypeNull indicates that the DIMSE message has no data payload,
+// when set in dicom.TagCommandDataSetType. Any other value indicates the
+// existence of a payload.
+const CommandDataSetTypeNull uint16 = 0x0101
+
+// CommandDataSetTypeNonNull indicates that the DIMSE message has a data
+// payload, when set in dicom.TagCommandDataSetType.
+const CommandDataSetTypeNonNull uint16 = 1

--- a/services/scp_test.go
+++ b/services/scp_test.go
@@ -63,7 +63,7 @@ func Test_Association_ID(t *testing.T) {
 }
 
 func Test_QRSCP(t *testing.T) {
-	port := 1043
+	port := 1044
 	_, testSCP := StartSCP(t, port)
 	testSCP.OnAssociationRequest(func(request *network.AAssociationRQ) bool { return true })
 	testSCP.OnCFindRequest(func(request *network.AAssociationRQ, queryLevel string, query *media.DcmObj) ([]*media.DcmObj, uint16) {

--- a/services/scu_test.go
+++ b/services/scu_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/t2care/obd-dicom/dictionary/tags"
@@ -167,19 +166,4 @@ func cFindReqByDate() *media.DcmObj {
 	queryDate.WriteString(tags.QueryRetrieveLevel, "STUDY")
 	queryDate.WriteString(tags.StudyDate, "20050323")
 	return queryDate
-}
-
-func StartSCP(t testing.TB, port int) (func(t testing.TB), *scp) {
-	testSCP := NewSCP(port)
-	go func() {
-		if err := testSCP.Start(); err != nil {
-			panic(err)
-		}
-	}()
-	time.Sleep(100 * time.Millisecond) // wait for server started
-	return func(t testing.TB) {
-		if err := testSCP.Stop(); err != nil {
-			panic(err)
-		}
-	}, testSCP
 }


### PR DESCRIPTION
- Fix bug for querySCP
- Add units tests

> W: DIMSE Warning: (FINDSCU,SCP): findUser: Status Success, but DataSetType!=NULL
W: DIMSE Warning: (FINDSCU,SCP): Assuming no response identifiers are present
I: Received Final Find Response (Success)
I: Releasing Association
E: Association Release Failed: 0006:0316 DUL P-Data PDU arrived