### PR TITLE
Linear scaling to 8 bits

### DIFF
--- a/dictionary/transfersyntax/uids.go
+++ b/dictionary/transfersyntax/uids.go
@@ -55,7 +55,7 @@ func SupportedTransferSyntax(uid string) bool {
 }
 
 type decodeFunc func(frame uint32, bitsa uint16, j2kData []byte, j2kSize uint32, outputData []byte, outputSize uint32) error
-type encodeFunc func(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, outData *[]byte, outSize *int, ratio int) error
+type encodeFunc func(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, outData *[]byte, outSize *int, ratio int) error
 
 var decodes = make(map[string]decodeFunc)
 var encodes = make(map[string]encodeFunc)
@@ -73,9 +73,9 @@ func (ts *TransferSyntax) Decode(frame uint32, bitsa uint16, j2kData []byte, j2k
 	return nil
 }
 
-func (ts *TransferSyntax) Encode(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, outData *[]byte, outSize *int, ratio int) error {
+func (ts *TransferSyntax) Encode(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, outData *[]byte, outSize *int, ratio int) error {
 	if fn, ok := encodes[ts.UID]; ok {
-		return fn(frame, RGB, rawData, width, height, samples, bitsa, outData, outSize, ratio)
+		return fn(frame, RGB, rawData, width, height, samples, bitsa, bitss, wc, ww, outData, outSize, ratio)
 	}
 	return nil
 }

--- a/dictionary/transfersyntax/uids.go
+++ b/dictionary/transfersyntax/uids.go
@@ -55,7 +55,7 @@ func SupportedTransferSyntax(uid string) bool {
 }
 
 type decodeFunc func(frame uint32, bitsa uint16, j2kData []byte, j2kSize uint32, outputData []byte, outputSize uint32) error
-type encodeFunc func(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, outData *[]byte, outSize *int, ratio int) error
+type encodeFunc func(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, outData *[]byte, outSize *int, ratio int) error
 
 var decodes = make(map[string]decodeFunc)
 var encodes = make(map[string]encodeFunc)
@@ -73,9 +73,9 @@ func (ts *TransferSyntax) Decode(frame uint32, bitsa uint16, j2kData []byte, j2k
 	return nil
 }
 
-func (ts *TransferSyntax) Encode(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, outData *[]byte, outSize *int, ratio int) error {
+func (ts *TransferSyntax) Encode(frame uint32, RGB bool, rawData []byte, width uint16, height uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, outData *[]byte, outSize *int, ratio int) error {
 	if fn, ok := encodes[ts.UID]; ok {
-		return fn(frame, RGB, rawData, width, height, samples, bitsa, bitss, wc, ww, outData, outSize, ratio)
+		return fn(frame, RGB, rawData, width, height, samples, bitsa, bitss, wc, ww, rs, ri, outData, outSize, ratio)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/t2care/obd-dicom
+module github.com/mateusz-t2/obd-dicom
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+) 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mateusz-t2/obd-dicom
+module github.com/t2care/obd-dicom
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-) 
+)

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -508,6 +508,7 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 
 	var i int
 	var rows, cols, bitss, bitsa, planar uint16
+	var wc, ww float64
 	var PhotoInt string
 	sq := 0
 	frames := uint32(0)
@@ -559,6 +560,10 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 					bitsa = tag.getUShort()
 				case 0x0101:
 					bitss = tag.getUShort()
+				case 0x1050:
+					wc, _ = strconv.ParseFloat(tag.getString(), 64)
+				case 0x1051:
+					ww, _ = strconv.ParseFloat(tag.getString(), 64)
 				}
 			}
 			if (tag.Group == 0x0088) && (tag.Element == 0x0200) && (tag.Length == 0xFFFFFFFF) {
@@ -600,7 +605,7 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 						copy(img, tag.Data)
 					}
 				}
-				if err := obj.compress(&i, img, RGB, cols, rows, bitss, bitsa, frames, outTS); err != nil {
+				if err := obj.compress(&i, img, RGB, cols, rows, bitss, wc, ww, bitsa, frames, outTS); err != nil {
 					return err
 				} else {
 					flag = true
@@ -753,7 +758,7 @@ func (obj *DcmObj) CreatePDF(study DCMStudy, SeriesInstanceUID string, SOPInstan
 	obj.WriteString(tags.MIMETypeOfEncapsulatedDocument, "application/pdf")
 }
 
-func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitss uint16, bitsa uint16, frames uint32, outTS *transfersyntax.TransferSyntax) error {
+func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitss uint16, wc, ww float64, bitsa uint16, frames uint32, outTS *transfersyntax.TransferSyntax) error {
 	mode := 0
 	switch outTS.UID {
 	case transfersyntax.JPEGLosslessSV1.UID:
@@ -791,10 +796,10 @@ func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint
 		obj.SetTag(index, tag)
 		return nil
 	}
-	return obj.encode(i, img, RGB, cols, rows, bitsa, bitss, frames, mode, outTS)
+	return obj.encode(i, img, RGB, cols, rows, bitsa, bitss, wc, ww, frames, mode, outTS)
 }
 
-func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, bitss uint16, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
+func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, bitss uint16, wc, ww float64, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
 	var JPEGData []byte
 	var JPEGBytes, index int
 	index = *i
@@ -817,7 +822,7 @@ func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16
 	obj.InsertTag(index, newtag)
 	for j := uint32(0); j < frames; j++ {
 		index++
-		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, bitss, float64(obj.GetUShort(tags.WindowCenter)), float64(obj.GetUShort(tags.WindowWidth)), &JPEGData, &JPEGBytes, mode); err != nil {
+		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, bitss, wc, ww, &JPEGData, &JPEGBytes, mode); err != nil {
 			return err
 		}
 		newtag = &DcmTag{

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -508,7 +508,7 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 
 	var i int
 	var rows, cols, bitss, bitsa, planar uint16
-	var wc, ww float64
+	var wc, ww, rs, ri float64
 	var PhotoInt string
 	sq := 0
 	frames := uint32(0)
@@ -561,9 +561,17 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 				case 0x0101:
 					bitss = tag.getUShort()
 				case 0x1050:
-					wc, _ = strconv.ParseFloat(tag.getString(), 64)
+					wcs := tag.getString()
+					wcs = strings.Split(wcs, "\\")[0]
+					wc, _ = strconv.ParseFloat(wcs, 64)
 				case 0x1051:
-					ww, _ = strconv.ParseFloat(tag.getString(), 64)
+					wws := tag.getString()
+					wws = strings.Split(wws, "\\")[0]
+					ww, _ = strconv.ParseFloat(wws, 64)
+				case 0x1052:
+					ri, _ = strconv.ParseFloat(tag.getString(), 64)
+				case 0x1053:
+					rs, _ = strconv.ParseFloat(tag.getString(), 64)
 				}
 			}
 			if (tag.Group == 0x0088) && (tag.Element == 0x0200) && (tag.Length == 0xFFFFFFFF) {
@@ -605,7 +613,7 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 						copy(img, tag.Data)
 					}
 				}
-				if err := obj.compress(&i, img, RGB, cols, rows, bitss, wc, ww, bitsa, frames, outTS); err != nil {
+				if err := obj.compress(&i, img, RGB, cols, rows, bitss, wc, ww, rs, ri, bitsa, frames, outTS); err != nil {
 					return err
 				} else {
 					flag = true
@@ -758,7 +766,7 @@ func (obj *DcmObj) CreatePDF(study DCMStudy, SeriesInstanceUID string, SOPInstan
 	obj.WriteString(tags.MIMETypeOfEncapsulatedDocument, "application/pdf")
 }
 
-func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitss uint16, wc, ww float64, bitsa uint16, frames uint32, outTS *transfersyntax.TransferSyntax) error {
+func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitss uint16, wc, ww, rs, ri float64, bitsa uint16, frames uint32, outTS *transfersyntax.TransferSyntax) error {
 	mode := 0
 	switch outTS.UID {
 	case transfersyntax.JPEGLosslessSV1.UID:
@@ -770,6 +778,8 @@ func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint
 		obj.WriteUint16(tags.PixelRepresentation, 0)
 		obj.WriteString(tags.WindowCenter, "127")
 		obj.WriteString(tags.WindowWidth, "255")
+		obj.WriteString(tags.RescaleIntercept, "0")
+		obj.WriteString(tags.RescaleSlope, "1")
 	case transfersyntax.JPEGExtended12Bit.UID:
 	case transfersyntax.JPEG2000.UID:
 		mode = 10
@@ -796,10 +806,10 @@ func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint
 		obj.SetTag(index, tag)
 		return nil
 	}
-	return obj.encode(i, img, RGB, cols, rows, bitsa, bitss, wc, ww, frames, mode, outTS)
+	return obj.encode(i, img, RGB, cols, rows, bitsa, bitss, wc, ww, rs, ri, frames, mode, outTS)
 }
 
-func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, bitss uint16, wc, ww float64, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
+func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, bitss uint16, wc, ww, rs, ri float64, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
 	var JPEGData []byte
 	var JPEGBytes, index int
 	index = *i
@@ -822,7 +832,7 @@ func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16
 	obj.InsertTag(index, newtag)
 	for j := uint32(0); j < frames; j++ {
 		index++
-		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, bitss, wc, ww, &JPEGData, &JPEGBytes, mode); err != nil {
+		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, bitss, wc, ww, rs, ri, &JPEGData, &JPEGBytes, mode); err != nil {
 			return err
 		}
 		newtag = &DcmTag{

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -759,6 +759,12 @@ func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint
 	case transfersyntax.JPEGLosslessSV1.UID:
 		mode = 4
 	case transfersyntax.JPEGBaseline8Bit.UID:
+		obj.WriteUint16(tags.BitsStored, 8)
+		obj.WriteUint16(tags.BitsAllocated, 8)
+		obj.WriteUint16(tags.HighBit, 7)
+		obj.WriteUint16(tags.PixelRepresentation, 0)
+		obj.WriteString(tags.WindowCenter, "127")
+		obj.WriteString(tags.WindowWidth, "255")
 	case transfersyntax.JPEGExtended12Bit.UID:
 	case transfersyntax.JPEG2000.UID:
 		mode = 10
@@ -785,10 +791,10 @@ func (obj *DcmObj) compress(i *int, img []byte, RGB bool, cols uint16, rows uint
 		obj.SetTag(index, tag)
 		return nil
 	}
-	return obj.encode(i, img, RGB, cols, rows, bitsa, frames, mode, outTS)
+	return obj.encode(i, img, RGB, cols, rows, bitsa, bitss, frames, mode, outTS)
 }
 
-func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
+func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16, bitsa uint16, bitss uint16, frames uint32, mode int, ts *transfersyntax.TransferSyntax) error {
 	var JPEGData []byte
 	var JPEGBytes, index int
 	index = *i
@@ -811,7 +817,7 @@ func (obj *DcmObj) encode(i *int, img []byte, RGB bool, cols uint16, rows uint16
 	obj.InsertTag(index, newtag)
 	for j := uint32(0); j < frames; j++ {
 		index++
-		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, &JPEGData, &JPEGBytes, mode); err != nil {
+		if err := ts.Encode(j, RGB, img, cols, rows, 1, bitsa, bitss, float64(obj.GetUShort(tags.WindowCenter)), float64(obj.GetUShort(tags.WindowWidth)), &JPEGData, &JPEGBytes, mode); err != nil {
 			return err
 		}
 		newtag = &DcmTag{

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -562,12 +562,10 @@ func (obj *DcmObj) ChangeTransferSynx(outTS *transfersyntax.TransferSyntax) erro
 					bitss = tag.getUShort()
 				case 0x1050:
 					wcs := tag.getString()
-					wcs = strings.Split(wcs, "\\")[0]
-					wc, _ = strconv.ParseFloat(wcs, 64)
+					wc, _ = strconv.ParseFloat(strings.Split(wcs, "\\")[0], 64)
 				case 0x1051:
 					wws := tag.getString()
-					wws = strings.Split(wws, "\\")[0]
-					ww, _ = strconv.ParseFloat(wws, 64)
+					ww, _ = strconv.ParseFloat(strings.Split(wws, "\\")[0], 64)
 				case 0x1052:
 					ri, _ = strconv.ParseFloat(tag.getString(), 64)
 				case 0x1053:

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -101,6 +101,9 @@ func changeSyntax(filename string, ts *transfersyntax.TransferSyntax) (err error
 	if err = dcmObj.ChangeTransferSynx(ts); err != nil {
 		return
 	}
+	if ts.Name == transfersyntax.JPEGBaseline8Bit.Name && dcmObj.GetUShort(tags.BitsAllocated) != 8 {
+		return fmt.Errorf("BitsAllocated must be 8 for JPEGBaseline8Bit transfer syntax")
+	}
 	out := "tmp"
 	if err = dcmObj.WriteToFile(out); err != nil {
 		return

--- a/media/transcoder/j2kcodec.go
+++ b/media/transcoder/j2kcodec.go
@@ -17,7 +17,7 @@ func decode(frame uint32, bitsa uint16, j2kData []byte, j2kSize uint32, outputDa
 	return openjpeg.J2Kdecode(j2kData, j2kSize, outputData[offset:])
 }
 
-func encode(frame uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, ratio int) error {
+func encode(frame uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, JPEGData *[]byte, JPEGBytes *int, ratio int) error {
 	offset := frame * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
 	if RGB {
 		offset = 3 * offset

--- a/media/transcoder/j2kcodec.go
+++ b/media/transcoder/j2kcodec.go
@@ -17,7 +17,7 @@ func decode(frame uint32, bitsa uint16, j2kData []byte, j2kSize uint32, outputDa
 	return openjpeg.J2Kdecode(j2kData, j2kSize, outputData[offset:])
 }
 
-func encode(frame uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, JPEGData *[]byte, JPEGBytes *int, ratio int) error {
+func encode(frame uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, ratio int) error {
 	offset := frame * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
 	if RGB {
 		offset = 3 * offset

--- a/media/transcoder/jpegCodec.go
+++ b/media/transcoder/jpegCodec.go
@@ -24,14 +24,19 @@ func jpegDecode(j uint32, bitsa uint16, in []byte, inSize uint32, out []byte, ou
 	}
 }
 
-func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, mode int) error {
-	offset := j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
+func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, JPEGData *[]byte, JPEGBytes *int, mode int) error {
+	offset := calcOffset(j, RGB, cols, rows, bitsa)
 	if RGB {
 		offset = 3 * offset
 	}
 
 	if bitsa == 16 {
-		img, _ = scale16to8(img, bitss, wc, ww)
+		var err error
+		img, err = scale16to8Bits(img, bitss, wc, ww, rs, ri)
+		if err != nil {
+			return err
+		}
+		offset = calcOffset(j, RGB, cols, rows, 8)
 	}
 
 	if RGB {
@@ -41,40 +46,48 @@ func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, sample
 	}
 }
 
-func scale16to8(img16 []byte, bitss uint16, wc, ww float64) ([]byte, error) {
+func calcOffset(j uint32, RGB bool, cols uint16, rows uint16, bitsa uint16) uint32 {
+	offset := j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
+	if RGB {
+		offset = 3 * offset
+	}
+	return offset
+}
+
+func scale16to8Bits(img16 []byte, bitss uint16, wc, ww, rs, ri float64) ([]byte, error) {
 	n := len(img16)
 	if n%2 != 0 {
-		return nil, fmt.Errorf("buffer 16 bits invalide (%d octets)", n)
+		return nil, fmt.Errorf("invalid 16-bit buffer size (%d bytes): the buffer size must be even", n)
 	}
 	out := make([]byte, n/2)
 
-	L := wc - ww/2.0
-	U := wc + ww/2.0
-	if L < 0 {
-		L = 0
-	}
-	maxRaw := float64(int(1) << bitss)
-	if U > maxRaw {
-		U = maxRaw
-	}
-	delta := U - L
-	if delta <= 0 {
-		delta = 1
+	if wc <= 0 || ww <= 0 {
+		maxRaw := float64(int(1) << bitss)
+		wc = maxRaw / 2.0
+		ww = maxRaw
 	}
 
 	for i := 0; i < n/2; i++ {
-		low := img16[2*i]
-		high := img16[2*i+1]
-		raw := float64(int(high)<<8 | int(low))
+		raw := float64(int(img16[2*i+1])<<8 | int(img16[2*i]))
 
-		if raw < L {
-			raw = L
-		} else if raw > U {
-			raw = U
+		//Apply modality rescale if provided
+		if rs != 0 && ri != 0 {
+			raw = raw*rs + ri
 		}
 
-		norm := (raw - L) * 255.0 / delta
-		out[i] = byte(norm)
+		co := wc - 0.5
+		hw := (ww - 1) / 2.0
+
+		//Linear conversion
+		var y float64
+		if raw <= co-hw {
+			y = 0
+		} else if raw > co+hw {
+			y = 255
+		} else {
+			y = ((raw-co)/(ww-1) + 0.5) * 255
+		}
+		out[i] = byte(y)
 	}
 	return out, nil
 }
@@ -84,7 +97,7 @@ func jpeg12Decode(j uint32, _ uint16, in []byte, inSize uint32, out []byte, outS
 	return jpeglib.DIJG12decode(in, inSize, out[offset:], outSize)
 }
 
-func jpeg12Encode(j uint32, _ bool, img []byte, cols uint16, rows uint16, _ uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, _ int) error {
+func jpeg12Encode(j uint32, _ bool, img []byte, cols uint16, rows uint16, _ uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, JPEGData *[]byte, JPEGBytes *int, _ int) error {
 	offset := j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
 	return jpeglib.EIJG12encode(img[offset/2:], cols, rows, 1, JPEGData, JPEGBytes, 0)
 }

--- a/media/transcoder/jpegCodec.go
+++ b/media/transcoder/jpegCodec.go
@@ -26,9 +26,6 @@ func jpegDecode(j uint32, bitsa uint16, in []byte, inSize uint32, out []byte, ou
 
 func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc, rs, ri float64, JPEGData *[]byte, JPEGBytes *int, mode int) error {
 	offset := calcOffset(j, RGB, cols, rows, bitsa)
-	if RGB {
-		offset = 3 * offset
-	}
 
 	if bitsa == 16 {
 		var err error

--- a/media/transcoder/jpegCodec.go
+++ b/media/transcoder/jpegCodec.go
@@ -29,7 +29,7 @@ func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, sample
 
 	if bitsa == 16 {
 		var err error
-		img, err = scale16to8Bits(img, bitss, wc, ww, rs, ri)
+		img, err = scaleTo8Bits(img, bitss, wc, ww, rs, ri)
 		if err != nil {
 			return err
 		}
@@ -51,7 +51,7 @@ func calcOffset(j uint32, RGB bool, cols uint16, rows uint16, bitsa uint16) uint
 	return offset
 }
 
-func scale16to8Bits(img16 []byte, bitss uint16, wc, ww, rs, ri float64) ([]byte, error) {
+func scaleTo8Bits(img16 []byte, bitss uint16, wc, ww, rs, ri float64) ([]byte, error) {
 	n := len(img16)
 	if n%2 != 0 {
 		return nil, fmt.Errorf("invalid 16-bit buffer size (%d bytes): the buffer size must be even", n)

--- a/media/transcoder/jpegCodec.go
+++ b/media/transcoder/jpegCodec.go
@@ -3,6 +3,8 @@
 package transcoder
 
 import (
+	"fmt"
+
 	"github.com/t2care/obd-dicom/dictionary/transfersyntax"
 	"github.com/t2care/obd-dicom/media/transcoder/jpeglib"
 )
@@ -22,20 +24,59 @@ func jpegDecode(j uint32, bitsa uint16, in []byte, inSize uint32, out []byte, ou
 	}
 }
 
-func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, JPEGData *[]byte, JPEGBytes *int, mode int) error {
+func jpegEncode(j uint32, RGB bool, img []byte, cols uint16, rows uint16, samples uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, mode int) error {
 	offset := j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
 	if RGB {
 		offset = 3 * offset
 	}
-	if bitsa == 8 {
-		if RGB {
-			return jpeglib.EIJG8encode(img[offset:], cols, rows, 3, JPEGData, JPEGBytes, mode)
-		} else {
-			return jpeglib.EIJG8encode(img[offset:], cols, rows, 1, JPEGData, JPEGBytes, mode)
-		}
-	} else {
-		return jpeglib.EIJG16encode(img[offset/2:], cols, rows, 1, JPEGData, JPEGBytes, 0)
+
+	if bitsa == 16 {
+		img, _ = scale16to8(img, bitss, wc, ww)
 	}
+
+	if RGB {
+		return jpeglib.EIJG8encode(img[offset:], cols, rows, 3, JPEGData, JPEGBytes, mode)
+	} else {
+		return jpeglib.EIJG8encode(img[offset:], cols, rows, 1, JPEGData, JPEGBytes, mode)
+	}
+}
+
+func scale16to8(img16 []byte, bitss uint16, wc, ww float64) ([]byte, error) {
+	n := len(img16)
+	if n%2 != 0 {
+		return nil, fmt.Errorf("buffer 16 bits invalide (%d octets)", n)
+	}
+	out := make([]byte, n/2)
+
+	L := wc - ww/2.0
+	U := wc + ww/2.0
+	if L < 0 {
+		L = 0
+	}
+	maxRaw := float64(int(1) << bitss)
+	if U > maxRaw {
+		U = maxRaw
+	}
+	delta := U - L
+	if delta <= 0 {
+		delta = 1
+	}
+
+	for i := 0; i < n/2; i++ {
+		low := img16[2*i]
+		high := img16[2*i+1]
+		raw := float64(int(high)<<8 | int(low))
+
+		if raw < L {
+			raw = L
+		} else if raw > U {
+			raw = U
+		}
+
+		norm := (raw - L) * 255.0 / delta
+		out[i] = byte(norm)
+	}
+	return out, nil
 }
 
 func jpeg12Decode(j uint32, _ uint16, in []byte, inSize uint32, out []byte, outSize uint32) error {
@@ -43,7 +84,7 @@ func jpeg12Decode(j uint32, _ uint16, in []byte, inSize uint32, out []byte, outS
 	return jpeglib.DIJG12decode(in, inSize, out[offset:], outSize)
 }
 
-func jpeg12Encode(j uint32, _ bool, img []byte, cols uint16, rows uint16, _ uint16, bitsa uint16, JPEGData *[]byte, JPEGBytes *int, _ int) error {
+func jpeg12Encode(j uint32, _ bool, img []byte, cols uint16, rows uint16, _ uint16, bitsa uint16, bitss uint16, ww, wc float64, JPEGData *[]byte, JPEGBytes *int, _ int) error {
 	offset := j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
 	return jpeglib.EIJG12encode(img[offset/2:], cols, rows, 1, JPEGData, JPEGBytes, 0)
 }


### PR DESCRIPTION
- Apply linear scaling to 8-bit output during JPEGBaseline8Bit transcoding
   - Update tags in dataset 

## Resources used

### Linear scaling formula:

Pseudo code:
```
if (x <= c - 0.5 - (w-1) /2), then y = ymin
else if (x > c - 0.5 + (w-1) /2), then y = ymax
else y = ((x - (c - 0.5)) / (w-1) + 0.5) * (ymax- ymin) + ymin
```

https://dicom.innolitics.com/ciods/ct-image/voi-lut/00281050

### CT Pixel Value Transformation formula:

```
Output units = m*SV + b
```

https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_c.8.15.3.10.html

## Benchmark

CGO: 
1000000000 0.04330 ns/op 0 B/op 0 allocs/op 

GO: 
1000000000 0.04167 ns/op 0 B/op 0 allocs/op

## Tests

Tested on MR, CT, CR, XA, MG, DX, US