### PR TITLE
Fix SCP returning C-MOVE request back to SCU after transfer

### DIFF
--- a/network/scp.go
+++ b/network/scp.go
@@ -114,7 +114,7 @@ func (s *scp) handleConnection(conn net.Conn) (err error) {
 				files, status = s.onCMoveRequest(pdu.GetAAssociationRQ(), moveLevel, ddo, dst)
 				scu := NewSCU(dst)
 				scu.onCStoreResult = func(pending, completed, failed uint16) error {
-					return pdu.WriteResp(command, dco, ddo, dicomstatus.Pending, completed, failed)
+					return pdu.WriteResp(command, dco, nil, dicomstatus.Pending, pending, completed, failed)
 				}
 				if err = scu.StoreSCU(files, 0); err != nil {
 					status = dicomstatus.CMoveOutOfResourcesUnableToPerformSubOperations

--- a/network/scp_test.go
+++ b/network/scp_test.go
@@ -102,7 +102,7 @@ func dcmtk_echoscu(port int) error {
 
 func exe(name string, args ...string) error {
 	out, err := exec.Command(name, args...).CombinedOutput()
-	if err != nil || strings.Contains(string(out), "E:") {
+	if err != nil || strings.Contains(string(out), "E:") || strings.Contains(string(out), "W:") {
 		return fmt.Errorf("%s", string(out))
 	}
 	fmt.Println(string(out)) // For debug logging

--- a/network/scp_test.go
+++ b/network/scp_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,7 +102,7 @@ func dcmtk_echoscu(port int) error {
 
 func exe(name string, args ...string) error {
 	out, err := exec.Command(name, args...).CombinedOutput()
-	if err != nil {
+	if err != nil || strings.Contains(string(out), "E:") {
 		return fmt.Errorf("%s", string(out))
 	}
 	fmt.Println(string(out)) // For debug logging


### PR DESCRIPTION
- Fix SCP returning C-MOVE request back to SCU after transfer
- Add "pending" info to response

## Diagram

```mermaid
sequenceDiagram
    participant SCU as Service Class User (SCU)
    participant SCP as Service Class Provider (SCP)
    participant DEST as Move Destination AE

    SCU->>SCP: C-MOVE Request (Destination AE: DEST)
    SCP->>DEST: C-STORE Request (Object 1)
    SCP->>DEST: C-STORE Request (Object 2)
    SCP-->>SCU: C-MOVE Response (Success / Completed)

    %% Unexpected behavior
    SCP-->>SCU: C-MOVE Request (same as original)
    Note right of SCP: SCP erroneously sends back the original C-MOVE request to the SCU
    Note over SCU: SCU receives the same C-MOVE request it initially sent
```

## Before/after changes

Command:

```bash
sudo movescu -d -v -aec STORE -aet MOVESCU -v -S -k 0008,0052=STUDY -k PatientID="T2.109_DICOMRM" -k StudyInstanceUID="1.3.6.1.4.1.19291.2.1.1.1708906721100004" localhost 1104
```

### Before

```bash
I: Requesting Association
I: Association Accepted (Max Send PDV: 16372)
I: Sending Move Request (MsgID 1)
I: Request Identifiers:
I: 
I: # Dicom-Data-Set
I: # Used TransferSyntax: Little Endian Explicit
I: (0008,0052) CS [STUDY]                                  #   6, 1 QueryRetrieveLevel
I: (0010,0020) LO [T2.109_DICOMRM]                         #  14, 1 PatientID
I: (0020,000d) UI [1.3.6.1.4.1.19291.2.1.1.1708906721100004] #  40, 1 StudyInstanceUID
I: 
W: DIMSE Warning: (MOVESCU,STORE): moveUser: Status Pending, but DataSetType!=NULL
W: DIMSE Warning: (MOVESCU,STORE): Assuming NO response identifiers are present
I: Received Move Response 1 (Pending)
W: DcmItem: Length of element (0008,0052) is odd
E: DcmElement: QueryRetrieveLevel (0008,0052) larger (414531) than remaining bytes (76) in file, premature end of stream
E: Move Request Failed: 0006:020d DIMSE: receiveCommand: cmdSet->read() Failed
E: 0001:0004 Invalid stream
E: Move SCU Failed: 0006:020d DIMSE: receiveCommand: cmdSet->read() Failed
E: 0001:0004 Invalid stream
I: Aborting Association
```

### After

```bash
I: Requesting Association
I: Association Accepted (Max Send PDV: 16372)
I: Sending Move Request (MsgID 1)
I: Request Identifiers:
I: 
I: # Dicom-Data-Set
I: # Used TransferSyntax: Little Endian Explicit
I: (0008,0052) CS [STUDY]                                  #   6, 1 QueryRetrieveLevel
I: (0010,0020) LO [T2.109_DICOMRM]                         #  14, 1 PatientID
I: (0020,000d) UI [1.3.6.1.4.1.19291.2.1.1.1708906721100004] #  40, 1 StudyInstanceUID
I: 
I: Received Move Response 1 (Pending)
I: Received Final Move Response (Success)
I: Releasing Association
```