### PR TITLE
add tags sorting option when writing Dicom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ obj.WriteToFile(fileName)
 ```golang
 obj, _ := media.NewDCMObjFromFile(fileName, &ParseOptions{SkipPixelData: true})
 obj.WriteString(tags.PatientName, "new value")
-obj.SortTagsByGroupAndElement()
-obj.WriteToFile(fileName)
+obj.WriteToFile(fileName, true)
 ```
 
 ### Send C-Echo Request

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ obj.WriteString(tags.PatientName, "new value")
 obj.WriteToFile(fileName)
 ```
 
+### Update string tag + tag sorting
+
+```golang
+obj, _ := media.NewDCMObjFromFile(fileName, &ParseOptions{SkipPixelData: true})
+obj.WriteString(tags.PatientName, "new value")
+obj.SortTagsByGroupAndElement()
+obj.WriteToFile(fileName)
+```
+
 ### Send C-Echo Request
 ```golang
 scu := network.NewSCU(destination)

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -194,22 +194,9 @@ func (obj *DcmObj) DumpTags() error {
 }
 
 func (obj *DcmObj) sortTagsByGroupAndElement() {
-	if obj.areTagsSortedByGroupAndElement() {
-		return
-	}
 	sort.Slice(obj.Tags, func(i, j int) bool {
 		return obj.Tags[i].isBefore(obj.Tags[j])
 	})
-	// sort the tags inside sequences
-	for _, tag := range obj.Tags {
-		if tag.isSequence() {
-			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
-			if !seq.areTagsSortedByGroupAndElement() {
-				seq.sortTagsByGroupAndElement()
-				tag.writeSeq(tag.Group, tag.Element, seq)
-			}
-		}
-	}
 }
 
 func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
@@ -303,10 +290,9 @@ func (obj *DcmObj) Add(tag *DcmTag) {
 }
 
 func (obj *DcmObj) WriteToBytes(opSortTags ...bool) []byte {
-	if len(opSortTags) > 0 {
-		if opSortTags[0] {
-			obj.sortTagsByGroupAndElement()
-		}
+	opSortTags = append(opSortTags, false)
+	if opSortTags[0] {
+		obj.sortTagsByGroupAndElement()
 	}
 	bufdata := NewEmptyBufData()
 	SOPClassUID := obj.getStringGE(0x08, 0x16)
@@ -323,11 +309,7 @@ func (obj *DcmObj) WriteToBytes(opSortTags ...bool) []byte {
 
 // Wrote - Write a DICOM Object to a DICOM File
 func (obj *DcmObj) WriteToFile(fileName string, opSortTags ...bool) error {
-	sortTags := false
-	if len(opSortTags) > 0 {
-		sortTags = opSortTags[0]
-	}
-	data := obj.WriteToBytes(sortTags)
+	data := obj.WriteToBytes(opSortTags...)
 	return os.WriteFile(fileName, data, 0644)
 }
 

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -23,7 +23,6 @@ type DcmObj struct {
 	TransferSyntax *transfersyntax.TransferSyntax
 	ExplicitVR     bool
 	BigEndian      bool
-	SQtag          *DcmTag
 	Size           int // bytes
 	CharSet        *encoding.Decoder
 }
@@ -42,7 +41,6 @@ func NewEmptyDCMObj() *DcmObj {
 		TransferSyntax: nil,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          &DcmTag{},
 	}
 }
 
@@ -81,7 +79,6 @@ func parseBufData(bufdata *BufData, opt ...*ParseOptions) (*DcmObj, error) {
 		TransferSyntax: transferSyntax,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          &DcmTag{},
 	}
 
 	if obj.TransferSyntax == nil {
@@ -696,14 +693,12 @@ func (obj *DcmObj) AddConceptNameSeq(group uint16, element uint16, CodeValue str
 		TransferSyntax: nil,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          new(DcmTag),
 	}
 	seq := &DcmObj{
 		Tags:           make([]*DcmTag, 0),
 		TransferSyntax: nil,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          new(DcmTag),
 	}
 	tag := new(DcmTag)
 
@@ -729,14 +724,12 @@ func (obj *DcmObj) AddSRText(text string) {
 		TransferSyntax: nil,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          new(DcmTag),
 	}
 	seq := &DcmObj{
 		Tags:           make([]*DcmTag, 0),
 		TransferSyntax: nil,
 		ExplicitVR:     false,
 		BigEndian:      false,
-		SQtag:          new(DcmTag),
 	}
 	tag := new(DcmTag)
 

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -199,15 +199,6 @@ func (obj *DcmObj) sortTagsByGroupAndElement() {
 	})
 }
 
-func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
-	for i := 0; i < (obj.TagCount() - 1); i++ {
-		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
-			return false
-		}
-	}
-	return true
-}
-
 func (obj *DcmObj) dumpSeq(indent int) error {
 	tabs := "\t"
 	for i := 0; i < indent; i++ {

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -196,8 +196,8 @@ func (obj *DcmObj) DumpTags() error {
 	return nil
 }
 
-func (obj *DcmObj) SortTagsByGroupAndElement() {
-	if obj.AreTagsSortedByGroupAndElement() {
+func (obj *DcmObj) sortTagsByGroupAndElement() {
+	if obj.areTagsSortedByGroupAndElement() {
 		return
 	}
 	sort.Slice(obj.Tags, func(i, j int) bool {
@@ -207,15 +207,15 @@ func (obj *DcmObj) SortTagsByGroupAndElement() {
 	for _, tag := range obj.Tags {
 		if tag.isSequence() {
 			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
-			if !seq.AreTagsSortedByGroupAndElement() {
-				seq.SortTagsByGroupAndElement()
+			if !seq.areTagsSortedByGroupAndElement() {
+				seq.sortTagsByGroupAndElement()
 				tag.writeSeq(tag.Group, tag.Element, seq)
 			}
 		}
 	}
 }
 
-func (obj *DcmObj) AreTagsSortedByGroupAndElement() bool {
+func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
 	for i := 0; i < (obj.TagCount() - 1); i++ {
 		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
 			return false
@@ -224,7 +224,7 @@ func (obj *DcmObj) AreTagsSortedByGroupAndElement() bool {
 	for _, tag := range obj.Tags {
 		if tag.isSequence() {
 			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
-			if !seq.AreTagsSortedByGroupAndElement() {
+			if !seq.areTagsSortedByGroupAndElement() {
 				return false
 			}
 		}
@@ -308,7 +308,7 @@ func (obj *DcmObj) Add(tag *DcmTag) {
 func (obj *DcmObj) WriteToBytes(opSortTags ...bool) []byte {
 	if len(opSortTags) > 0 {
 		if opSortTags[0] {
-			obj.SortTagsByGroupAndElement()
+			obj.sortTagsByGroupAndElement()
 		}
 	}
 	bufdata := NewEmptyBufData()

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -305,7 +305,12 @@ func (obj *DcmObj) Add(tag *DcmTag) {
 	obj.Tags = append(obj.Tags, tag)
 }
 
-func (obj *DcmObj) WriteToBytes() []byte {
+func (obj *DcmObj) WriteToBytes(opSortTags ...bool) []byte {
+	if len(opSortTags) > 0 {
+		if opSortTags[0] {
+			obj.SortTagsByGroupAndElement()
+		}
+	}
 	bufdata := NewEmptyBufData()
 	SOPClassUID := obj.getStringGE(0x08, 0x16)
 	SOPInstanceUID := obj.getStringGE(0x08, 0x18)
@@ -320,8 +325,12 @@ func (obj *DcmObj) WriteToBytes() []byte {
 }
 
 // Wrote - Write a DICOM Object to a DICOM File
-func (obj *DcmObj) WriteToFile(fileName string) error {
-	data := obj.WriteToBytes()
+func (obj *DcmObj) WriteToFile(fileName string, opSortTags ...bool) error {
+	sortTags := false
+	if len(opSortTags) > 0 {
+		sortTags = opSortTags[0]
+	}
+	data := obj.WriteToBytes(sortTags)
 	return os.WriteFile(fileName, data, 0644)
 }
 

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -190,6 +191,21 @@ func (obj *DcmObj) DumpTags() error {
 	}
 	fmt.Println()
 	return nil
+}
+
+func (obj *DcmObj) SortTagsByGroupAndElement() {
+	sort.Slice(obj.Tags, func(i, j int) bool {
+		return obj.Tags[i].isBefore(obj.Tags[j])
+	})
+}
+
+func (obj *DcmObj) AreTagsSortedByGroupAndElement() bool {
+	for i := 0; i < (obj.TagCount() - 1); i++ {
+		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
+			return false
+		}
+	}
+	return true
 }
 
 func (obj *DcmObj) dumpSeq(indent int) error {

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -205,14 +205,6 @@ func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
 			return false
 		}
 	}
-	for _, tag := range obj.Tags {
-		if tag.isSequence() {
-			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
-			if !seq.areTagsSortedByGroupAndElement() {
-				return false
-			}
-		}
-	}
 	return true
 }
 

--- a/media/dcm_obj.go
+++ b/media/dcm_obj.go
@@ -197,15 +197,36 @@ func (obj *DcmObj) DumpTags() error {
 }
 
 func (obj *DcmObj) SortTagsByGroupAndElement() {
+	if obj.AreTagsSortedByGroupAndElement() {
+		return
+	}
 	sort.Slice(obj.Tags, func(i, j int) bool {
 		return obj.Tags[i].isBefore(obj.Tags[j])
 	})
+	// sort the tags inside sequences
+	for _, tag := range obj.Tags {
+		if tag.isSequence() {
+			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
+			if !seq.AreTagsSortedByGroupAndElement() {
+				seq.SortTagsByGroupAndElement()
+				tag.writeSeq(tag.Group, tag.Element, seq)
+			}
+		}
+	}
 }
 
 func (obj *DcmObj) AreTagsSortedByGroupAndElement() bool {
 	for i := 0; i < (obj.TagCount() - 1); i++ {
 		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
 			return false
+		}
+	}
+	for _, tag := range obj.Tags {
+		if tag.isSequence() {
+			seq, _ := tag.ReadSeq(obj.IsExplicitVR())
+			if !seq.AreTagsSortedByGroupAndElement() {
+				return false
+			}
 		}
 	}
 	return true

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -344,9 +344,9 @@ func TestTagsSorting(t *testing.T) {
 
 		}
 
-		assert.Equal(t, tt.isSorted, dicom.AreTagsSortedByGroupAndElement(), "original tags sequence is sorted or not")
-		dicom.SortTagsByGroupAndElement()
-		assert.Equal(t, true, dicom.AreTagsSortedByGroupAndElement(), "tags sequence is sorted")
+		assert.Equal(t, tt.isSorted, dicom.areTagsSortedByGroupAndElement(), "original tags sequence is sorted or not")
+		dicom.sortTagsByGroupAndElement()
+		assert.Equal(t, true, dicom.areTagsSortedByGroupAndElement(), "tags sequence is sorted")
 
 	}
 }

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -302,6 +302,24 @@ func TestCharSetEncoder(t *testing.T) {
 	}
 }
 
+func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
+	for i := 0; i < (obj.TagCount() - 1); i++ {
+		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
+			return false
+		}
+	}
+	return true
+}
+
+func areTagsSortedByGroupAndElement(obj *DcmObj) bool {
+	for i := 0; i < (obj.TagCount() - 1); i++ {
+		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
+			return false
+		}
+	}
+	return true
+}
+
 func TestTagsSorting(t *testing.T) {
 	InitDict()
 	tests := []struct {
@@ -452,9 +470,9 @@ func TestTagsSorting(t *testing.T) {
 
 		}
 
-		assert.Equal(t, tt.isSorted, dicom.areTagsSortedByGroupAndElement(), fmt.Sprint(tt.name, ": original tags are sorting should be ", tt.isSorted))
+		assert.Equal(t, tt.isSorted, areTagsSortedByGroupAndElement(dicom), fmt.Sprint(tt.name, ": original tags are sorting should be ", tt.isSorted))
 		dicom.sortTagsByGroupAndElement()
-		assert.Equal(t, true, dicom.areTagsSortedByGroupAndElement(), fmt.Sprint(tt.name, ": tags are not sorted"))
+		assert.Equal(t, true, areTagsSortedByGroupAndElement(dicom), fmt.Sprint(tt.name, ": tags are not sorted"))
 
 	}
 }
@@ -466,16 +484,18 @@ func Shuffle[T any](slice []T) {
 	}
 }
 
-func BenchmarkTagsSortingPreShuffled(b *testing.B) {
+func BenchmarkWritingSorting(b *testing.B) {
 	df, _ := NewDCMObjFromFile("../samples/rle_color.dcm")
-	{
-		// randomize the tags order
-		Shuffle(df.Tags)
-	}
-	df.WriteToFile("../samples/rle_color-shuffled.dcm", false)
 
-	for i := 0; i < b.N; i++ {
-		df, _ := NewDCMObjFromFile("../samples/rle_color-shuffled.dcm")
-		df.WriteToFile("../samples/rle_color-shuffled-sorted.dcm", true)
-	}
+	b.Run("WriteToFile Sorting Off", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			df.WriteToFile("../samples/rle_color-notsorted.dcm")
+		}
+	})
+
+	b.Run("WriteToFile Sorting On", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			df.WriteToFile("../samples/rle_color-sorted.dcm", true)
+		}
+	})
 }

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -323,8 +323,25 @@ func TestTagsSorting(t *testing.T) {
 	for _, tt := range tests {
 
 		dicom := NewEmptyDCMObj()
-		for _, tag := range tt.tags {
-			dicom.WriteString(tag, "not an empty tag")
+
+		for idx, tag := range tt.tags {
+			dicom.WriteString(tag, fmt.Sprintf("tag #%d", idx))
+		}
+		{ //write add a sequence with tags
+			seq := &DcmObj{
+				Tags:           make([]*DcmTag, 0),
+				TransferSyntax: dicom.TransferSyntax,
+				ExplicitVR:     dicom.ExplicitVR,
+				BigEndian:      dicom.BigEndian,
+				SQtag:          &DcmTag{},
+			}
+			for idx, tag := range tt.tags {
+				seq.WriteString(tag, fmt.Sprintf("seq tag #%d", idx))
+			}
+			tag := new(DcmTag)
+			tag.writeSeq(0xFFFE, 0xE000, seq)
+			dicom.Add(tag)
+
 		}
 
 		assert.Equal(t, tt.isSorted, dicom.AreTagsSortedByGroupAndElement(), "original tags sequence is sorted or not")

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -333,7 +333,6 @@ func TestTagsSorting(t *testing.T) {
 				TransferSyntax: dicom.TransferSyntax,
 				ExplicitVR:     dicom.ExplicitVR,
 				BigEndian:      dicom.BigEndian,
-				SQtag:          &DcmTag{},
 			}
 			for idx, tag := range tt.tags {
 				seq.WriteString(tag, fmt.Sprintf("seq tag #%d", idx))

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -270,3 +270,36 @@ func Test_WriteString(t *testing.T) {
 		assert.Equal(t, tt.newValue, o.GetString(tt.tag), tt.name)
 	}
 }
+
+func TestTagsSorting(t *testing.T) {
+	InitDict()
+	tests := []struct {
+		name     string
+		tags     []*tags.Tag
+		isSorted bool
+	}{
+		{
+			name:     "Sorted tags",
+			tags:     []*tags.Tag{tags.StudyDate, tags.AccessionNumber, tags.StudyInstanceUID},
+			isSorted: true,
+		},
+		{
+			name:     "Unsorted tags",
+			tags:     []*tags.Tag{tags.SeriesInstanceUID, tags.SeriesDescription, tags.StudyDate, tags.AccessionNumber, tags.StudyInstanceUID},
+			isSorted: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		dicom := NewEmptyDCMObj()
+		for _, tag := range tt.tags {
+			dicom.WriteString(tag, "not an empty tag")
+		}
+
+		assert.Equal(t, tt.isSorted, dicom.AreTagsSortedByGroupAndElement(), "original tags sequence is sorted or not")
+		dicom.SortTagsByGroupAndElement()
+		assert.Equal(t, true, dicom.AreTagsSortedByGroupAndElement(), "tags sequence is sorted")
+
+	}
+}

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -302,15 +302,6 @@ func TestCharSetEncoder(t *testing.T) {
 	}
 }
 
-func (obj *DcmObj) areTagsSortedByGroupAndElement() bool {
-	for i := 0; i < (obj.TagCount() - 1); i++ {
-		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
-			return false
-		}
-	}
-	return true
-}
-
 func areTagsSortedByGroupAndElement(obj *DcmObj) bool {
 	for i := 0; i < (obj.TagCount() - 1); i++ {
 		if !obj.GetTagAt(i).isBefore(obj.GetTagAt(i + 1)) {
@@ -328,18 +319,30 @@ func TestTagsSorting(t *testing.T) {
 		isSorted bool
 	}{
 		{
-			name:     "Sorted tags",
-			tags:     []*tags.Tag{tags.StudyDate, tags.AccessionNumber, tags.StudyInstanceUID},
+			name:     "Zero tags",
+			tags:     []*tags.Tag{},
 			isSorted: true,
 		},
 		{
-			name:     "Unsorted tags",
-			tags:     []*tags.Tag{tags.SeriesInstanceUID, tags.SeriesDescription, tags.StudyDate, tags.AccessionNumber, tags.StudyInstanceUID},
-			isSorted: false,
+			name: "Sorted tags",
+			tags: []*tags.Tag{
+				tags.PagePositionID,
+				tags.TextFormatID,
+				tags.NormalReverse,
+				tags.AddGrayScale,
+				tags.Borders,
+				tags.Copies,
+				tags.CommandMagnificationType,
+				tags.Erase,
+				tags.Print,
+				tags.Overlays,
+			},
+			isSorted: true,
 		},
 		{
-			name: "Unsorted random 100 tags",
-			tags: []*tags.Tag{tags.ActualFrameDuration,
+			name: "Unsorted tags",
+			tags: []*tags.Tag{
+				tags.ActualFrameDuration,
 				tags.OtherPatientIDsSequence,
 				tags.SegmentationCreationTemplateLabel,
 				tags.ReferencedDefinedDeviceIndex,
@@ -350,141 +353,24 @@ func TestTagsSorting(t *testing.T) {
 				tags.NumberOfFractionPatternDigitsPerDay,
 				tags.ROIObservationDescription,
 				tags.PositionerSecondaryAngle,
-				tags.Signature,
-				tags.ConfidentialityConstraintOnPatientDataDescription,
-				tags.XRayDetectorID,
-				tags.GPSSatellites,
-				tags.TreatmentStatusComment,
-				tags.CodingSchemeVersion,
-				tags.ImageRotation,
-				tags.VisualFieldTestPointNormalsSequence,
-				tags.GPSDestLongitude,
-				tags.BscanSlabThickness,
-				tags.SegmentReferenceSequence,
-				tags.StorageProtocolElementSpecificationSequence,
-				tags.TargetRefraction,
-				tags.PatientLocationCoordinatesCodeSequence,
-				tags.MeasurementFunctions,
-				tags.AnteriorChamberDepthDefinitionCodeSequence,
-				tags.RTBeamLimitingDeviceOffset,
-				tags.UDISequence,
-				tags.ScanStopPositionSequence,
-				tags.TextString,
-				tags.RefractivePower,
-				tags.RangeOfFreedom,
-				tags.CollimatorShapeSequence,
-				tags.GPSDestLatitude,
-				tags.DocumentTitle,
-				tags.ISOSpeedLatitudeyyy,
-				tags.TransferSyntaxUID,
-				tags.DoseRateDelivered,
-				tags.VolumeToTableMappingMatrix,
-				tags.XRay3DFrameTypeSequence,
-				tags.ElementShape,
-				tags.OphthalmicPatientClinicalInformationRightEyeSequence,
-				tags.NumberOfFractionsPlanned,
-				tags.SourceInstanceSequence,
-				tags.AcquisitionsInStudy,
-				tags.PercentSampling,
-				tags.CalculatedDoseReferenceSequence,
-				tags.ImpedanceMeasurementCurrentType,
-				tags.NotificationFromManufacturerSequence,
-				tags.NumberOfWaveformSamples,
-				tags.ModalitiesInStudy,
-				tags.ReferencedAccessionSequenceTrial,
-				tags.ImageIndex,
-				tags.InterpretationIDIssuer,
-				tags.ControlPoint3DPosition,
-				tags.PixelComponentMask,
-				tags.DisplayWindowLabelVector,
-				tags.ImageBoxNumber,
-				tags.CountsSource,
-				tags.ReferringPhysicianTelephoneNumbers,
-				tags.BlockSlabNumber,
-				tags.PrinterStatusInfo,
-				tags.ApplicationSetupType,
-				tags.AcquisitionStartConditionData,
-				tags.RangeShifterSettingsSequence,
-				tags.TransferTubeNumber,
-				tags.DeliveredDepthDoseParametersSequence,
-				tags.ReferencedVOILUTBoxSequence,
-				tags.BillingSuppliesAndDevicesSequence,
-				tags.OperatingModeSequence,
-				tags.OverrideParameterPointer,
-				tags.ROIElementalCompositionAtomicNumber,
-				tags.RecommendedViewingMode,
-				tags.AnchorPointVisibility,
-				tags.BolusDefinitionSequence,
-				tags.MeasuredValueSequence,
-				tags.DICOMRetrievalSequence,
-				tags.FocalLengthIn35mmFilm,
-				tags.VolumeLocalizationSequence,
-				tags.TransducerOrientation,
-				tags.BlockThickness,
-				tags.ReferencedImageBoxSequenceRetired,
-				tags.ReferencedReferenceImageNumber,
-				tags.Pressure,
-				tags.HardcopyDeviceManufacturer,
-				tags.NumberOfLateralSpreadingDevices,
-				tags.SetupTechnique,
-				tags.ReferencedRTPrescriptionIndex,
-				tags.DetectorConfiguration,
-				tags.ReferencedSeriesSequence,
-				tags.PositionerIsocenterDetectorRotationAngle,
-				tags.SourceApplicatorName,
-				tags.AlgorithmSource,
-				tags.ShieldingDeviceLabel,
-				tags.ReferencedRadiationDoseIdentificationIndex,
-				tags.PriorRecordKey,
-				tags.NominalBeamEnergy,
-				tags.DataPointRows,
-				tags.VerifyingObserverName},
+			},
 			isSorted: false,
 		},
 	}
 
 	for _, tt := range tests {
-
 		dicom := NewEmptyDCMObj()
-
-		if !tt.isSorted {
-
-		}
-
 		for idx, tag := range tt.tags {
 			dicom.WriteString(tag, fmt.Sprintf("tag #%d", idx))
-		}
-		{ //write add a sequence with tags
-			seq := &DcmObj{
-				Tags:           make([]*DcmTag, 0),
-				TransferSyntax: dicom.TransferSyntax,
-				ExplicitVR:     dicom.ExplicitVR,
-				BigEndian:      dicom.BigEndian,
-			}
-			for idx, tag := range tt.tags {
-				seq.WriteString(tag, fmt.Sprintf("seq tag #%d", idx))
-			}
-			tag := new(DcmTag)
-			tag.writeSeq(0xFFFE, 0xE000, seq)
-			dicom.Add(tag)
-
 		}
 
 		assert.Equal(t, tt.isSorted, areTagsSortedByGroupAndElement(dicom), fmt.Sprint(tt.name, ": original tags are sorting should be ", tt.isSorted))
 		dicom.sortTagsByGroupAndElement()
 		assert.Equal(t, true, areTagsSortedByGroupAndElement(dicom), fmt.Sprint(tt.name, ": tags are not sorted"))
-
 	}
 }
 
-func Shuffle[T any](slice []T) {
-	for i := len(slice) - 1; i > 0; i-- {
-		j := rand.IntN(i + 1) // Random index from 0 to i
-		slice[i], slice[j] = slice[j], slice[i]
-	}
-}
-
-func BenchmarkWritingSorting(b *testing.B) {
+func BenchmarkWritingSortingOffOn(b *testing.B) {
 	df, _ := NewDCMObjFromFile("../samples/rle_color.dcm")
 
 	b.Run("WriteToFile Sorting Off", func(b *testing.B) {
@@ -496,6 +382,27 @@ func BenchmarkWritingSorting(b *testing.B) {
 	b.Run("WriteToFile Sorting On", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			df.WriteToFile("../samples/rle_color-sorted.dcm", true)
+		}
+	})
+}
+
+func Shuffle[T any](slice []T) {
+	for i := len(slice) - 1; i > 0; i-- {
+		j := rand.IntN(i + 1) // Random index from 0 to i
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}
+func BenchmarkSortingAllPublicTags(b *testing.B) {
+
+	dicom := NewEmptyDCMObj()
+	for idx, tag := range tags.GetTags() {
+		dicom.WriteString(tag, fmt.Sprintf("tag #%d", idx))
+	}
+	Shuffle(dicom.GetTags())
+
+	b.Run(fmt.Sprintf("Sorting %d tags", len(dicom.GetTags())), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			dicom.sortTagsByGroupAndElement()
 		}
 	})
 }

--- a/media/dcm_obj_test.go
+++ b/media/dcm_obj_test.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"testing"
@@ -318,11 +319,119 @@ func TestTagsSorting(t *testing.T) {
 			tags:     []*tags.Tag{tags.SeriesInstanceUID, tags.SeriesDescription, tags.StudyDate, tags.AccessionNumber, tags.StudyInstanceUID},
 			isSorted: false,
 		},
+		{
+			name: "Unsorted random 100 tags",
+			tags: []*tags.Tag{tags.ActualFrameDuration,
+				tags.OtherPatientIDsSequence,
+				tags.SegmentationCreationTemplateLabel,
+				tags.ReferencedDefinedDeviceIndex,
+				tags.RequestedProcedureCodeSequence,
+				tags.AttenuationCorrectionMethod,
+				tags.PETPositionSequence,
+				tags.DataSetName,
+				tags.NumberOfFractionPatternDigitsPerDay,
+				tags.ROIObservationDescription,
+				tags.PositionerSecondaryAngle,
+				tags.Signature,
+				tags.ConfidentialityConstraintOnPatientDataDescription,
+				tags.XRayDetectorID,
+				tags.GPSSatellites,
+				tags.TreatmentStatusComment,
+				tags.CodingSchemeVersion,
+				tags.ImageRotation,
+				tags.VisualFieldTestPointNormalsSequence,
+				tags.GPSDestLongitude,
+				tags.BscanSlabThickness,
+				tags.SegmentReferenceSequence,
+				tags.StorageProtocolElementSpecificationSequence,
+				tags.TargetRefraction,
+				tags.PatientLocationCoordinatesCodeSequence,
+				tags.MeasurementFunctions,
+				tags.AnteriorChamberDepthDefinitionCodeSequence,
+				tags.RTBeamLimitingDeviceOffset,
+				tags.UDISequence,
+				tags.ScanStopPositionSequence,
+				tags.TextString,
+				tags.RefractivePower,
+				tags.RangeOfFreedom,
+				tags.CollimatorShapeSequence,
+				tags.GPSDestLatitude,
+				tags.DocumentTitle,
+				tags.ISOSpeedLatitudeyyy,
+				tags.TransferSyntaxUID,
+				tags.DoseRateDelivered,
+				tags.VolumeToTableMappingMatrix,
+				tags.XRay3DFrameTypeSequence,
+				tags.ElementShape,
+				tags.OphthalmicPatientClinicalInformationRightEyeSequence,
+				tags.NumberOfFractionsPlanned,
+				tags.SourceInstanceSequence,
+				tags.AcquisitionsInStudy,
+				tags.PercentSampling,
+				tags.CalculatedDoseReferenceSequence,
+				tags.ImpedanceMeasurementCurrentType,
+				tags.NotificationFromManufacturerSequence,
+				tags.NumberOfWaveformSamples,
+				tags.ModalitiesInStudy,
+				tags.ReferencedAccessionSequenceTrial,
+				tags.ImageIndex,
+				tags.InterpretationIDIssuer,
+				tags.ControlPoint3DPosition,
+				tags.PixelComponentMask,
+				tags.DisplayWindowLabelVector,
+				tags.ImageBoxNumber,
+				tags.CountsSource,
+				tags.ReferringPhysicianTelephoneNumbers,
+				tags.BlockSlabNumber,
+				tags.PrinterStatusInfo,
+				tags.ApplicationSetupType,
+				tags.AcquisitionStartConditionData,
+				tags.RangeShifterSettingsSequence,
+				tags.TransferTubeNumber,
+				tags.DeliveredDepthDoseParametersSequence,
+				tags.ReferencedVOILUTBoxSequence,
+				tags.BillingSuppliesAndDevicesSequence,
+				tags.OperatingModeSequence,
+				tags.OverrideParameterPointer,
+				tags.ROIElementalCompositionAtomicNumber,
+				tags.RecommendedViewingMode,
+				tags.AnchorPointVisibility,
+				tags.BolusDefinitionSequence,
+				tags.MeasuredValueSequence,
+				tags.DICOMRetrievalSequence,
+				tags.FocalLengthIn35mmFilm,
+				tags.VolumeLocalizationSequence,
+				tags.TransducerOrientation,
+				tags.BlockThickness,
+				tags.ReferencedImageBoxSequenceRetired,
+				tags.ReferencedReferenceImageNumber,
+				tags.Pressure,
+				tags.HardcopyDeviceManufacturer,
+				tags.NumberOfLateralSpreadingDevices,
+				tags.SetupTechnique,
+				tags.ReferencedRTPrescriptionIndex,
+				tags.DetectorConfiguration,
+				tags.ReferencedSeriesSequence,
+				tags.PositionerIsocenterDetectorRotationAngle,
+				tags.SourceApplicatorName,
+				tags.AlgorithmSource,
+				tags.ShieldingDeviceLabel,
+				tags.ReferencedRadiationDoseIdentificationIndex,
+				tags.PriorRecordKey,
+				tags.NominalBeamEnergy,
+				tags.DataPointRows,
+				tags.VerifyingObserverName},
+			isSorted: false,
+		},
 	}
 
 	for _, tt := range tests {
 
 		dicom := NewEmptyDCMObj()
+
+		if !tt.isSorted {
+
+		}
 
 		for idx, tag := range tt.tags {
 			dicom.WriteString(tag, fmt.Sprintf("tag #%d", idx))
@@ -343,9 +452,30 @@ func TestTagsSorting(t *testing.T) {
 
 		}
 
-		assert.Equal(t, tt.isSorted, dicom.areTagsSortedByGroupAndElement(), "original tags sequence is sorted or not")
+		assert.Equal(t, tt.isSorted, dicom.areTagsSortedByGroupAndElement(), fmt.Sprint(tt.name, ": original tags are sorting should be ", tt.isSorted))
 		dicom.sortTagsByGroupAndElement()
-		assert.Equal(t, true, dicom.areTagsSortedByGroupAndElement(), "tags sequence is sorted")
+		assert.Equal(t, true, dicom.areTagsSortedByGroupAndElement(), fmt.Sprint(tt.name, ": tags are not sorted"))
 
+	}
+}
+
+func Shuffle[T any](slice []T) {
+	for i := len(slice) - 1; i > 0; i-- {
+		j := rand.IntN(i + 1) // Random index from 0 to i
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}
+
+func BenchmarkTagsSortingPreShuffled(b *testing.B) {
+	df, _ := NewDCMObjFromFile("../samples/rle_color.dcm")
+	{
+		// randomize the tags order
+		Shuffle(df.Tags)
+	}
+	df.WriteToFile("../samples/rle_color-shuffled.dcm", false)
+
+	for i := 0; i < b.N; i++ {
+		df, _ := NewDCMObjFromFile("../samples/rle_color-shuffled.dcm")
+		df.WriteToFile("../samples/rle_color-shuffled-sorted.dcm", true)
 	}
 }

--- a/media/dcm_tag.go
+++ b/media/dcm_tag.go
@@ -150,3 +150,10 @@ func (tag *DcmTag) isSequenceUndefined() bool {
 func (tag *DcmTag) isSequenceEnd() bool {
 	return (tag.Group == 0xFFFE && tag.Element == 0xE00D) || (tag.Group == 0xFFFE && tag.Element == 0xE0DD)
 }
+
+func (tag *DcmTag) isBefore(otherTag *DcmTag) bool {
+	if tag.Group != otherTag.Group {
+		return tag.Group < otherTag.Group
+	}
+	return tag.Element < otherTag.Element
+}

--- a/media/dcm_tag_test.go
+++ b/media/dcm_tag_test.go
@@ -1,0 +1,60 @@
+package media
+
+import (
+	"testing"
+)
+
+func TestTagSorting(t *testing.T) {
+	InitDict()
+
+	type DcmTags struct {
+		tagA DcmTag
+		tagB DcmTag
+	}
+
+	tests := []struct {
+		name     string
+		args     DcmTags
+		expected bool
+	}{
+		{
+			name: "sorted tags, higher element id",
+			args: DcmTags{tagA: DcmTag{Group: 0x0000, Element: 0x0000},
+				tagB: DcmTag{Group: 0x0000, Element: 0x0001},
+			},
+			expected: true,
+		},
+		{
+			name: "sorted tags, higher group & element ids",
+			args: DcmTags{tagA: DcmTag{Group: 0x0000, Element: 0x0000},
+				tagB: DcmTag{Group: 0x0009, Element: 0x0004},
+			},
+			expected: true,
+		},
+		{
+			name: "unsorted tags",
+			args: DcmTags{tagA: DcmTag{Group: 0x0100, Element: 0x0005},
+				tagB: DcmTag{Group: 0x0000, Element: 0x0001},
+			},
+			expected: false,
+		},
+		{
+			name: "same group, same element",
+			args: DcmTags{tagA: DcmTag{Group: 0x0777, Element: 0x0042},
+				tagB: DcmTag{Group: 0x0777, Element: 0x0042},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret := tt.args.tagA.isBefore(&tt.args.tagB)
+
+			if ret != tt.expected {
+				t.Errorf("DcmTag.isBefore() returns %v, expected %v", ret, tt.expected)
+				return
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Add tags sorting option the the `DcmObj` `WriteToFile(...)` & `WriteToBytes(...)` functions.

_when the option is set to `true`, the tags are sorted by groups/elements (following Dicom standard compliance)._

benchmark writing to file without and with sorting :
<img width="1050" height="160" alt="image" src="https://github.com/user-attachments/assets/f95b1771-1ba6-407e-ae67-243ff5a4d7f6" />

benchmark sorting function over all shuffled 5000+ public tags:
<img width="986" height="139" alt="image" src="https://github.com/user-attachments/assets/5fc33c76-803d-40f0-a4d1-518caf239629" />

Note: remove unused `DcmObj.SQtag` field